### PR TITLE
Update to 9.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# This is a good default: files that are auto-detected by git to be text are
+# converted to the platform-native line ending (LF on Unix, CRLF on Windows)
+# in the working tree and to LF in the repository.
+#
+* text=auto
+
+# Use `eol=crlf` for files that should have the CRLF line ending both in the
+# working tree (even on Unix) and in the repository.
+#
+#*.bat text eol=crlf
+
+# Use `eol=lf` for files that should have the LF line ending both in the
+# working tree (even on Windows) and in the repository.
+#
+#*.sh text eol=lf
+
+# Use `binary` to make sure certain files are never auto-detected as text.
+#
+#*.png binary
+
+fmt/include symlink=dir
+fmt/src symlink=dir
+doc symlink=dir

--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 : 1
 name: fmt
-version: 8.1.1
+version: 9.0.0
 summary: "{fmt} is an open-source formatting library for C++. It can be used as a safe and fast alternative to (s)printf and iostreams."
 license: MIT
 description-file: README.md
@@ -9,6 +9,6 @@ url: https://github.com/fmtlib/fmt/
 package-url: https://github.com/build2-packaging/fmt/
 package-email: mjklaim@gmail.com
 
-depends: * build2 >= 0.13.0
-depends: * bpkg >= 0.13.0
+depends: * build2 >= 0.15.0
+depends: * bpkg >= 0.15.0
 


### PR DESCRIPTION
Just done the basics so far, not attempted to address #2 .

Had a look and don't see any obvious upstream changes that would need to be dealt with.

I'm kinda miffed by some compilation errors. Building tests was failing for me on `8.1.1` with MSVC `19.32+`, as well as Clang (though in general the package worked, I'd been using it in my project). Was seeing same errors for MSVC on Compiler Explorer. `19.31` worked.
Then I switched upstream to `9.0.0`, ran `b test` and got success on all versions of MSVC and Clang too, so I figured the problem was with `fmt` and had been fixed. But now, having changed nothing more as far as I'm aware, the errors are back. Let me know how it is for you when you have chance.