### PR TITLE
fmt v11 and c++20 modules support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,3 +21,5 @@
 fmt/fmt/include symlink=dir
 fmt/fmt/src symlink=dir
 fmt/doc symlink=dir
+fmt-tests/basics/test symlink=dir
+fmt-tests/test-main/test symlink=dir

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .bdep/
+.vs/
 
 # Local default options files.
 #

--- a/fmt-tests/.gitignore
+++ b/fmt-tests/.gitignore
@@ -1,0 +1,25 @@
+# Compiler/linker output.
+#
+*.d
+*.t
+*.i
+*.i.*
+*.ii
+*.ii.*
+*.o
+*.obj
+*.gcm
+*.pcm
+*.ifc
+*.so
+*.dylib
+*.dll
+*.a
+*.lib
+*.exp
+*.pdb
+*.ilk
+*.exe
+*.exe.dlls/
+*.exe.manifest
+*.pc

--- a/fmt-tests/basics/.gitignore
+++ b/fmt-tests/basics/.gitignore
@@ -1,0 +1,5 @@
+basics
+
+# Testscript output directory (can be symlink).
+#
+test-basics

--- a/fmt-tests/basics/buildfile
+++ b/fmt-tests/basics/buildfile
@@ -1,0 +1,37 @@
+include ../test-main/
+
+#test_names =
+#  args-test \
+#  assert-test \
+#  base-test
+gtest_test_names = args-test assert-test base-test chrono-test color-test compile-fp-test compile-test format-test gtest-extra-test noexception-test os-test ostream-test posix-mock-test printf-test ranges-odr-test ranges-test std-test unicode-test xchar-test
+# header-only-test
+# scan-test
+
+standalone_test_names = enforce-checks-test # some way to pair these? -DFMT_ENFORCE_COMPILE_STRING
+
+for test_name : $gtest_test_names
+{
+  ./: exe{$test_name} : test/cxx{$test_name}
+  exe{$test_name}: ../test-main/liba{test-main}:
+  {
+    bin.whole = true
+  }
+}
+
+# linker issues.
+#./: exe{scan-test} : test/cxx{scan-test} ../test-main/liba{test-main}
+
+# @todo: cmake adds this test conditionally on NOT ( msvc AND fmt-shared )
+# in build2, i guess it's a bit different in that we can potentially build both shared and static variants within a single config?
+# also not clear how fmt_shared/fmt_header_only is being configured, looks like the package doesn't do anything there. using defaults only?
+# if $cxx. != msvc
+#./: exe{format-impl-test} : test/cxx{format-impl-test header-only-test} ../test-main/liba{test-main}
+
+
+import fmt = fmt%lib{fmt}
+
+for test_name : $standalone_test_names
+{
+  ./: exe{$test_name} : test/cxx{$test_name} $fmt
+}

--- a/fmt-tests/basics/buildfile
+++ b/fmt-tests/basics/buildfile
@@ -1,16 +1,31 @@
 include ../test-main/
 
-#test_names =
-#  args-test \
-#  assert-test \
-#  base-test
-gtest_test_names = args-test assert-test base-test chrono-test color-test compile-fp-test compile-test format-test gtest-extra-test noexception-test os-test ostream-test printf-test std-test unicode-test xchar-test
+# NOTE: Maintaining explicit lists to match upstream, as it's not clear that there is intended to be a uniform pattern that can be reliably globbed.
+# See individual invocations of add_fmt_test() in upstream/test/CMakeLists.txt
 
-# header-only-test <- header only mode seemingly not supported by this build2 package?
-# scan-test <- some linker issues
-# posix-mock-test <- needs posix-mock.h, and has some msvc/runtime conditional logic going on
 
-standalone_test_names = enforce-checks-test # some way to pair these? -DFMT_ENFORCE_COMPILE_STRING
+# Tests that use gtest, and do not require any additional source/headers beyond a single cc file
+
+gtest_test_names =      \
+  args-test             \
+  assert-test           \
+  base-test             \
+  chrono-test           \
+  color-test            \
+  compile-fp-test       \
+  compile-test          \
+  format-test           \
+  gtest-extra-test      \
+  noexception-test      \
+  os-test               \
+  ostream-test          \
+  printf-test           \
+  std-test              \
+  unicode-test          \
+  xchar-test
+
+# NOTE: header-only-test - Excluded as this package does not currently provide support for FMT_HEADER_ONLY.
+# TODO: scan-test - Excluded due to unresolved linker errors.
 
 for test_name : $gtest_test_names
 {
@@ -21,21 +36,28 @@ for test_name : $gtest_test_names
   }
 }
 
+# END [Tests that use gtest, and do not require any additional source/headers beyond a single cc file]
+
+
+# Tests using gtest but with additional prerequisites
+
 ./: exe{ranges-test} : test/cxx{ranges-test ranges-odr-test}
 exe{ranges-test}: ../test-main/liba{test-main}:
 {
   bin.whole = true
 }
 
-# linker issues.
-#./: exe{scan-test} : test/cxx{scan-test} ../test-main/liba{test-main}
+# NOTE: format-impl-test- For whatever reason, format-impl-test is tied in upstream to header-only-test, which we do not support. Attempting to compile it alone yields errors, therefore omitted.
+# TODO: posix-mock-test - Excluded pending further work. Needs posix-mock.h, and has some msvc/runtime conditional logic that needs looking into.
 
-# @todo: cmake adds this test conditionally on NOT ( msvc AND fmt-shared )
-# in build2, i guess it's a bit different in that we can potentially build both shared and static variants within a single config?
-# also not clear how fmt_shared/fmt_header_only is being configured, looks like the package doesn't do anything there. using defaults only?
-# if $cxx. != msvc
-#./: exe{format-impl-test} : test/cxx{format-impl-test header-only-test} ../test-main/liba{test-main}
+# END [Tests using gtest but with additional prerequisites]
 
+
+# Tests which do not use gtest and therefore should link directly to fmt only and not the test-main lib
+
+# TODO: Is there a clean way to use a declarative list but with more structure, in order to pair names to additional options?
+standalone_test_names = \
+  enforce-checks-test           # -DFMT_ENFORCE_COMPILE_STRING
 
 import fmt = fmt%lib{fmt}
 
@@ -43,3 +65,5 @@ for test_name : $standalone_test_names
 {
   ./: exe{$test_name} : test/cxx{$test_name} $fmt
 }
+
+# END [Tests which do not use gtest and therefore should link directly to fmt only and not the test-main lib]

--- a/fmt-tests/basics/buildfile
+++ b/fmt-tests/basics/buildfile
@@ -4,7 +4,7 @@ include ../test-main/
 #  args-test \
 #  assert-test \
 #  base-test
-gtest_test_names = args-test assert-test base-test chrono-test color-test compile-fp-test compile-test format-test gtest-extra-test noexception-test os-test ostream-test printf-test ranges-odr-test ranges-test std-test unicode-test xchar-test
+gtest_test_names = args-test assert-test base-test chrono-test color-test compile-fp-test compile-test format-test gtest-extra-test noexception-test os-test ostream-test printf-test std-test unicode-test xchar-test
 
 # header-only-test <- header only mode seemingly not supported by this build2 package?
 # scan-test <- some linker issues
@@ -19,6 +19,12 @@ for test_name : $gtest_test_names
   {
     bin.whole = true
   }
+}
+
+./: exe{ranges-test} : test/cxx{ranges-test ranges-odr-test}
+exe{ranges-test}: ../test-main/liba{test-main}:
+{
+  bin.whole = true
 }
 
 # linker issues.

--- a/fmt-tests/basics/buildfile
+++ b/fmt-tests/basics/buildfile
@@ -4,9 +4,11 @@ include ../test-main/
 #  args-test \
 #  assert-test \
 #  base-test
-gtest_test_names = args-test assert-test base-test chrono-test color-test compile-fp-test compile-test format-test gtest-extra-test noexception-test os-test ostream-test posix-mock-test printf-test ranges-odr-test ranges-test std-test unicode-test xchar-test
-# header-only-test
-# scan-test
+gtest_test_names = args-test assert-test base-test chrono-test color-test compile-fp-test compile-test format-test gtest-extra-test noexception-test os-test ostream-test printf-test ranges-odr-test ranges-test std-test unicode-test xchar-test
+
+# header-only-test <- header only mode seemingly not supported by this build2 package?
+# scan-test <- some linker issues
+# posix-mock-test <- needs posix-mock.h, and has some msvc/runtime conditional logic going on
 
 standalone_test_names = enforce-checks-test # some way to pair these? -DFMT_ENFORCE_COMPILE_STRING
 

--- a/fmt-tests/basics/test
+++ b/fmt-tests/basics/test
@@ -1,0 +1,1 @@
+../../upstream/test

--- a/fmt-tests/build/.gitignore
+++ b/fmt-tests/build/.gitignore
@@ -1,0 +1,4 @@
+/config.build
+/root/
+/bootstrap/
+build/

--- a/fmt-tests/build/bootstrap.build
+++ b/fmt-tests/build/bootstrap.build
@@ -3,5 +3,4 @@ project = fmt-tests
 using version
 using config
 using test
-using install
 using dist

--- a/fmt-tests/build/bootstrap.build
+++ b/fmt-tests/build/bootstrap.build
@@ -1,0 +1,7 @@
+project = fmt-tests
+
+using version
+using config
+using test
+using install
+using dist

--- a/fmt-tests/build/root.build
+++ b/fmt-tests/build/root.build
@@ -10,6 +10,10 @@ hxx{*}: extension = h
 mxx{*}: extension = cc
 cxx{*}: extension = cc
 
+# All executables are tests
+#
+exe{*}: test = true
+
 # The test target for cross-testing (running tests under Wine, etc).
 #
 test.target = $cxx.target

--- a/fmt-tests/build/root.build
+++ b/fmt-tests/build/root.build
@@ -1,0 +1,15 @@
+# Uncomment to suppress warnings coming from external libraries.
+#
+#cxx.internal.scope = current
+
+cxx.std = latest
+
+using cxx
+
+hxx{*}: extension = h
+mxx{*}: extension = cc
+cxx{*}: extension = cc
+
+# The test target for cross-testing (running tests under Wine, etc).
+#
+test.target = $cxx.target

--- a/fmt-tests/buildfile
+++ b/fmt-tests/buildfile
@@ -1,0 +1,1 @@
+./: {*/ -build/} manifest

--- a/fmt-tests/manifest
+++ b/fmt-tests/manifest
@@ -1,0 +1,13 @@
+: 1
+name: fmt-tests
+version: 0.1.0-a.0.z
+project: fmt
+summary: Tests package for fmt upstream tests
+license: MIT
+url: https://github.com/fmtlib/fmt/
+
+depends: * build2 >= 0.17.0
+depends: * bpkg >= 0.17.0
+
+depends: gtest ^1.11.0
+depends: gmock ^1.11.0

--- a/fmt-tests/manifest
+++ b/fmt-tests/manifest
@@ -1,6 +1,6 @@
 : 1
 name: fmt-tests
-version: 0.1.0-a.0.z
+version: 11.0.1-a.0.z
 project: fmt
 summary: Tests package for fmt upstream tests
 license: MIT

--- a/fmt-tests/test-main/buildfile
+++ b/fmt-tests/test-main/buildfile
@@ -1,0 +1,13 @@
+
+libs =
+import libs += fmt%lib{fmt}
+import libs += gtest%lib{gtest} gmock%lib{gmock}
+
+liba{test-main}: test/cxx{test-main gtest-extra util} test/hxx{gtest-extra} $libs
+
+# Export options.
+#
+liba{test-main}:
+{
+  cxx.export.libs = $libs
+}

--- a/fmt-tests/test-main/buildfile
+++ b/fmt-tests/test-main/buildfile
@@ -3,11 +3,12 @@ libs =
 import libs += fmt%lib{fmt}
 import libs += gtest%lib{gtest} gmock%lib{gmock}
 
-liba{test-main}: test/cxx{test-main gtest-extra util} test/hxx{gtest-extra} $libs
+liba{test-main}: test/cxx{test-main gtest-extra util} test/hxx{gtest-extra mock-allocator test-assert util} $libs
 
 # Export options.
 #
 liba{test-main}:
 {
+  cxx.export.poptions += "-I$src_base/test"
   cxx.export.libs = $libs
 }

--- a/fmt-tests/test-main/test
+++ b/fmt-tests/test-main/test
@@ -1,0 +1,1 @@
+../../upstream/test

--- a/fmt/README.md
+++ b/fmt/README.md
@@ -9,9 +9,18 @@ See [`{fmt}` documentation](https://fmt.dev/) for usage and details.
 Note: This is the source code for the build2 package of the `{fmt}` C++ library,
 the actual library sources snapshot can be found in the `./upstream/` submodule.
 
-## Configuration Options:
+## Configuration Options
 
- - `config.fmt.enable_modules` : Set to `true` to build and provide the `fmt` C++ modules. If the compiler and C++ version don't support C++ modules (which is C++ > 20), this will result in a compilation failure. Set to `true` if `$cxx.features.modules == true` which means the configuration is set to enable C++ modules, `false` otherwise.
+### Experimental C++20 modules support
 
+Modules support is WIP, both in the `build2` package and also in `fmt` upstream. Latest versions of MSVC or Clang are recommended, and the most up-to-date version of the package with regards to modules compatibility can be used via git and the [modules branch](https://github.com/build2-packaging/fmt/tree/modules). For example, in project `repositories.manifest`:
+```
+:
+role: prerequisite
+location: https://github.com/build2-packaging/fmt.git#modules
+```
 
+Enable with `config.cxx.features.modules=true`. When enabled, by default dual mode is used meaning that the library can be consumed either through `import` or via `#include`. To enable this safely, all entities are attached to the global module (extern "C++"). See `modules_only` option for the alternative.
+ - `config.fmt.enable_import_std` : Set to `true` to consume the standard library as a module when building the `fmt` module. Support dependent on compiler and std lib. Defaults to `false`.
+ - `config.fmt.modules_only` : Set to `true` to enable modules-only mode for the package. In this mode, `fmt` entities are fully encapsulated in the `fmt` module meaning `#include`-based consumption cannot be mixed, and the package will not export headers. Defaults to `false`.
 

--- a/fmt/build/root.build
+++ b/fmt/build/root.build
@@ -14,6 +14,3 @@ test.target = $cxx.target
 ##############################
 # Project-specific options:
 
-# Set to true to build and provide the `fmt` C++ module.
-config [bool] config.fmt.enable_modules ?= $cxx.features.modules # $($cxx.features.modules == true)
-

--- a/fmt/build/root.build
+++ b/fmt/build/root.build
@@ -15,3 +15,4 @@ test.target = $cxx.target
 # Project-specific options:
 
 config [bool]    config.fmt.enable_import_std ?= false
+config [bool]    config.fmt.modules_only ?= false

--- a/fmt/build/root.build
+++ b/fmt/build/root.build
@@ -14,3 +14,4 @@ test.target = $cxx.target
 ##############################
 # Project-specific options:
 
+config [bool]    config.fmt.enable_import_std ?= false

--- a/fmt/fmt/buildfile
+++ b/fmt/fmt/buildfile
@@ -36,8 +36,9 @@ hxx{version} : in{version} $src_root/manifest
 cxx.poptions =+ "-I$src_base/include" "-I$out_root" "-I$src_root"
 {objs bmis}{*}: cxx.poptions += -DFMT_LIB_EXPORT
 
+# If building fmt module, also enable attaching to the global module in order to allow concurrent #include and import.
 if($build_fmt_module)
-  cxx.poptions =+ -DFMT_MODULE
+  cxx.poptions =+ -DFMT_MODULE -DFMT_ATTACH_TO_GLOBAL_MODULE
 
 # Export options.
 #

--- a/fmt/fmt/buildfile
+++ b/fmt/fmt/buildfile
@@ -13,6 +13,10 @@ allow_header_usage = ($build_fmt_module == false || $config.fmt.modules_only == 
 if($build_fmt_module && $allow_header_usage)
   info "Building fmt with dual module/header mode enabled"
 
+# Workaround for MSVC bug: https://developercommunity.visualstudio.com/t/Separate-preprocessing-with-P-fails-wit/10707183
+if($build_fmt_module && $cxx.class == 'msvc')
+  cxx.reprocess = true
+
 lib{fmt}: src/mxx{fmt} : include = ($build_fmt_module) # `fmt` C++ module only
 lib{fmt}: src/cxx{** -fmt} : include = (!$build_fmt_module) # no modules only
 

--- a/fmt/fmt/buildfile
+++ b/fmt/fmt/buildfile
@@ -6,14 +6,17 @@ imp_libs = # Implementation dependencies.
 
 lib{fmt}: include/hxx{**} hxx{version} $imp_libs $int_libs
 
-lib{fmt}: src/mxx{fmt} : include = ($config.fmt.enable_modules) # `fmt` C++ module only
-lib{fmt}: src/cxx{** -fmt} : include = (!$config.fmt.enable_modules) # no modules only
+# Automatically build as module if the feature is enabled
+build_fmt_module = $cxx.features.modules
+
+lib{fmt}: src/mxx{fmt} : include = ($build_fmt_module) # `fmt` C++ module only
+lib{fmt}: src/cxx{** -fmt} : include = (!$build_fmt_module) # no modules only
 
 # Meta data for users
 lib{fmt}:
 {
   export.metadata = 1 fmt
-  fmt.is_module = [bool] $config.fmt.enable_modules
+  fmt.is_module = [bool] $build_fmt_module
 }
 
 # Include the generated version header into the distribution (so that we don't
@@ -33,8 +36,8 @@ hxx{version} : in{version} $src_root/manifest
 cxx.poptions =+ "-I$src_base/include" "-I$out_root" "-I$src_root"
 objs{*}: cxx.poptions += -DFMT_LIB_EXPORT
 
-if($config.fmt.enable_modules)
-  cxx.poptions =+ -DFMT_MODULE=ON
+if($build_fmt_module)
+  cxx.poptions =+ -DFMT_MODULE
 
 # Export options.
 #

--- a/fmt/fmt/buildfile
+++ b/fmt/fmt/buildfile
@@ -15,7 +15,7 @@ if($build_fmt_module && $allow_header_usage)
 
 # Workaround for MSVC bug: https://developercommunity.visualstudio.com/t/Separate-preprocessing-with-P-fails-wit/10707183
 if($build_fmt_module && $cxx.class == 'msvc')
-  cxx.reprocess = true
+  cc.reprocess = true
 
 lib{fmt}: src/mxx{fmt} : include = ($build_fmt_module) # `fmt` C++ module only
 lib{fmt}: src/cxx{** -fmt} : include = (!$build_fmt_module) # no modules only

--- a/fmt/fmt/buildfile
+++ b/fmt/fmt/buildfile
@@ -34,7 +34,7 @@ hxx{version} : in{version} $src_root/manifest
 # Build options.
 #
 cxx.poptions =+ "-I$src_base/include" "-I$out_root" "-I$src_root"
-objs{*}: cxx.poptions += -DFMT_LIB_EXPORT
+{objs bmis}{*}: cxx.poptions += -DFMT_LIB_EXPORT
 
 if($build_fmt_module)
   cxx.poptions =+ -DFMT_MODULE

--- a/fmt/fmt/buildfile
+++ b/fmt/fmt/buildfile
@@ -8,6 +8,10 @@ lib{fmt}: include/hxx{**} hxx{version} $imp_libs $int_libs
 
 # Automatically build as module if the feature is enabled
 build_fmt_module = $cxx.features.modules
+allow_header_usage = ($build_fmt_module == false || $config.fmt.modules_only == false)
+
+if($build_fmt_module && $allow_header_usage)
+  info "Building fmt with dual module/header mode enabled"
 
 lib{fmt}: src/mxx{fmt} : include = ($build_fmt_module) # `fmt` C++ module only
 lib{fmt}: src/cxx{** -fmt} : include = (!$build_fmt_module) # no modules only
@@ -16,7 +20,8 @@ lib{fmt}: src/cxx{** -fmt} : include = (!$build_fmt_module) # no modules only
 lib{fmt}:
 {
   export.metadata = 1 fmt
-  fmt.is_module = [bool] $build_fmt_module
+  fmt.has_header = [bool] $allow_header_usage
+  fmt.has_module = [bool] $build_fmt_module
 }
 
 # Include the generated version header into the distribution (so that we don't
@@ -38,20 +43,23 @@ cxx.poptions =+ "-I$src_base/include" "-I$out_root" "-I$src_root"
 
 # If building fmt module, also enable attaching to the global module in order to allow concurrent #include and import.
 if($build_fmt_module)
-  cxx.poptions =+ -DFMT_MODULE -DFMT_ATTACH_TO_GLOBAL_MODULE
+{
+  cxx.poptions =+ -DFMT_MODULE
+  if($allow_header_usage)
+    # Support mixing consuming as both modules and headers within a single build
+    cxx.poptions =+ -DFMT_ATTACH_TO_GLOBAL_MODULE
   if($config.fmt.enable_import_std)
     cxx.poptions =+ -DFMT_IMPORT_STD
+}
 
 # Export options.
 #
-lib{fmt}:
+lib{fmt}: cxx.export.libs = $int_libs
+if($allow_header_usage) # Note: exported poptions only relevant for header consumption
 {
-  cxx.export.poptions = "-I$src_base/include" "-I$out_root" "-I$src_root"
-  cxx.export.libs = $int_libs
+  lib{fmt}: cxx.export.poptions = "-I$src_base/include" "-I$out_root" "-I$src_root"
+  libs{fmt}: cxx.export.poptions += -DFMT_SHARED
 }
-
-libs{fmt}: cxx.export.poptions += -DFMT_SHARED
-
 
 # For pre-releases use the complete version to make sure they cannot be used
 # in place of another pre-release or the final version. See the version module

--- a/fmt/fmt/buildfile
+++ b/fmt/fmt/buildfile
@@ -39,6 +39,8 @@ cxx.poptions =+ "-I$src_base/include" "-I$out_root" "-I$src_root"
 # If building fmt module, also enable attaching to the global module in order to allow concurrent #include and import.
 if($build_fmt_module)
   cxx.poptions =+ -DFMT_MODULE -DFMT_ATTACH_TO_GLOBAL_MODULE
+  if($config.fmt.enable_import_std)
+    cxx.poptions =+ -DFMT_IMPORT_STD
 
 # Export options.
 #

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -13,3 +13,6 @@ tests: fmt-tests == $
 
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
+
+modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
+modules-only-build-config: config.cxx.features.modules=true config.fmt.modules_only=true ; Enable c++20 modules and disable header usage

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -14,6 +14,11 @@ tests: fmt-tests == $
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
 
+builds: default
+builds: -freebsd							; fmt tests failing, fixed on upstream master, pending removal next package release after 11.0.2
+build-exclude: linux_debian_12-clang_17		; clang-17 bug with libstdc++ std::tuple (https://github.com/llvm/llvm-project/issues/61415)
+build-exclude: **/x86_64-w64-mingw32		; unknown error building installed tests 'error: unable to stat path D:\a\msys64\mingw64\lib\x86_64-w64-mingw32\14.1.0\pkgconfig\: the device is not ready'
+
 #modules-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
 #modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
 #modules-only-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -14,5 +14,7 @@ tests: fmt-tests == $
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
 
+modules-builds: latest;
 modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
+modules-only-builds: latest;
 modules-only-build-config: config.cxx.features.modules=true config.fmt.modules_only=true ; Enable c++20 modules and disable header usage

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -14,7 +14,7 @@ tests: fmt-tests == $
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
 
-modules-builds: experimental : &( +clang-18+ ) ; Modules builds only supported for latest Clang and MSVC
+modules-builds: experimental : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
 modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
-modules-only-builds: experimental : &( +clang-18+ ) ; Modules builds only supported for latest Clang and MSVC
+modules-only-builds: experimental : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
 modules-only-build-config: config.cxx.features.modules=true config.fmt.modules_only=true ; Enable c++20 modules and disable header usage

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -14,7 +14,7 @@ tests: fmt-tests == $
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
 
-modules-builds: latest : &( +clang-18+ ) ; Modules builds only supported for latest Clang and MSVC
+modules-builds: experimental : &( +clang-18+ ) ; Modules builds only supported for latest Clang and MSVC
 modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
-modules-only-builds: latest : &( +clang-18+ ) ; Modules builds only supported for latest Clang and MSVC
+modules-only-builds: experimental : &( +clang-18+ ) ; Modules builds only supported for latest Clang and MSVC
 modules-only-build-config: config.cxx.features.modules=true config.fmt.modules_only=true ; Enable c++20 modules and disable header usage

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -14,7 +14,7 @@ tests: fmt-tests == $
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
 
-modules-builds: latest;
+modules-builds: latest : &( +clang-18+ ) ; Modules builds only supported for latest Clang and MSVC
 modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
-modules-only-builds: latest;
+modules-only-builds: latest : &( +clang-18+ ) ; Modules builds only supported for latest Clang and MSVC
 modules-only-build-config: config.cxx.features.modules=true config.fmt.modules_only=true ; Enable c++20 modules and disable header usage

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -14,7 +14,7 @@ tests: fmt-tests == $
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
 
-modules-builds: experimental : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
+modules-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
 modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
-modules-only-builds: experimental : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
+modules-only-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
 modules-only-build-config: config.cxx.features.modules=true config.fmt.modules_only=true ; Enable c++20 modules and disable header usage

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -19,6 +19,7 @@ builds: -freebsd							; fmt tests failing, fixed on upstream master, pending re
 build-exclude: linux_debian_12-clang_17		; clang-17 bug with libstdc++ std::tuple (https://github.com/llvm/llvm-project/issues/61415)
 build-exclude: **/x86_64-w64-mingw32		; unknown error building installed tests 'error: unable to stat path D:\a\msys64\mingw64\lib\x86_64-w64-mingw32\14.1.0\pkgconfig\: the device is not ready'
 
+# Modules support still not sufficient to enable on CI
 #modules-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
 #modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
 #modules-only-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -9,6 +9,7 @@ url: https://github.com/fmtlib/fmt/
 package-url: https://github.com/build2-packaging/fmt/
 package-email: mjklaim@gmail.com
 
+tests: fmt-tests == $
+
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
-

--- a/fmt/manifest
+++ b/fmt/manifest
@@ -14,7 +14,7 @@ tests: fmt-tests == $
 depends: * build2 >= 0.17.0
 depends: * bpkg >= 0.17.0
 
-modules-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
-modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
-modules-only-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
-modules-only-build-config: config.cxx.features.modules=true config.fmt.modules_only=true ; Enable c++20 modules and disable header usage
+#modules-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
+#modules-build-config: config.cxx.features.modules=true ; Enable c++20 modules
+#modules-only-builds: latest : &( +clang-18+ +msvc ) ; Modules builds only supported for latest Clang and MSVC
+#modules-only-build-config: config.cxx.features.modules=true config.fmt.modules_only=true ; Enable c++20 modules and disable header usage

--- a/fmt/tests/basics/buildfile
+++ b/fmt/tests/basics/buildfile
@@ -1,7 +1,5 @@
 import! [metadata, rule_hint=cxx.link] libs = fmt%lib{fmt}
 
-./ :
-
 ./ : exe{driver} : include = $($libs: fmt.has_header)
 ./ : exe{driver-modules} : include = $($libs: fmt.has_module)
 

--- a/fmt/tests/basics/buildfile
+++ b/fmt/tests/basics/buildfile
@@ -1,14 +1,13 @@
 import! [metadata, rule_hint=cxx.link] libs = fmt%lib{fmt}
 
-if $($libs: fmt.has_header)
-{
-  ./ : exe{driver} : {cxx}{driver} hxx{tests.inl} $libs testscript{**}
-}
+./ :
 
-if $($libs: fmt.has_module)
-{
-  # For purposes of verifying that fmt headers are not made available for include when in modules-only mode
-  cxx.poptions =+ "-DFMT_BUILD2_HAS_HEADER=($($libs: fmt.has_header) ? 1 : 0)"
+./ : exe{driver} : include = $($libs: fmt.has_header)
+./ : exe{driver-modules} : include = $($libs: fmt.has_module)
 
-  ./ : exe{driver-modules} : {cxx}{driver-modules} hxx{tests.inl} $libs testscript{**}
-}
+exe{driver} : {cxx}{driver} hxx{tests.inl} $libs testscript{**}
+
+# For purposes of verifying that fmt headers are not made available for include when in modules-only mode
+cxx.poptions =+ "-DFMT_BUILD2_HAS_HEADER=($($libs: fmt.has_header) ? 1 : 0)"
+
+exe{driver-modules} : {cxx}{driver-modules} hxx{tests.inl} $libs testscript{**}

--- a/fmt/tests/basics/buildfile
+++ b/fmt/tests/basics/buildfile
@@ -1,9 +1,14 @@
 import! [metadata, rule_hint=cxx.link] libs = fmt%lib{fmt}
 
-./ : exe{driver} : {cxx}{driver} hxx{tests.inl} $libs testscript{**}
-
-if $($libs: fmt.is_module)
+if $($libs: fmt.has_header)
 {
-    ./ : exe{driver-modules} : {cxx}{driver-modules} hxx{tests.inl} $libs testscript{**}
+  ./ : exe{driver} : {cxx}{driver} hxx{tests.inl} $libs testscript{**}
 }
 
+if $($libs: fmt.has_module)
+{
+  # For purposes of verifying that fmt headers are not made available for include when in modules-only mode
+  cxx.poptions =+ "-DFMT_BUILD2_HAS_HEADER=($($libs: fmt.has_header) ? 1 : 0)"
+
+  ./ : exe{driver-modules} : {cxx}{driver-modules} hxx{tests.inl} $libs testscript{**}
+}

--- a/fmt/tests/basics/driver-modules.cxx
+++ b/fmt/tests/basics/driver-modules.cxx
@@ -1,4 +1,9 @@
 
+// Verify that fmt headers are not available if config.fmt.modules_only is true
+#if __has_include(<fmt/version.h>) != FMT_BUILD2_HAS_HEADER
+#error fmt headers should be available for include iff config.fmt.modules_only == false
+#endif
+
 #include <cassert>
 #include <string>
 #include <chrono>
@@ -7,5 +12,3 @@
 import fmt;
 
 #include "tests.inl"
-
-

--- a/fmt/tests/basics/driver-modules.cxx
+++ b/fmt/tests/basics/driver-modules.cxx
@@ -1,6 +1,9 @@
 
 #include <cassert>
-import std;
+#include <string>
+#include <chrono>
+#include <vector>
+
 import fmt;
 
 #include "tests.inl"

--- a/fmt/tests/basics/driver.cxx
+++ b/fmt/tests/basics/driver.cxx
@@ -1,4 +1,5 @@
 #include <cassert>
+#include <string>
 #include <chrono>
 #include <vector>
 

--- a/fmt/tests/basics/tests.inl
+++ b/fmt/tests/basics/tests.inl
@@ -51,7 +51,8 @@ struct date {
 
 template <>
 struct fmt::formatter<date> {
-  constexpr auto parse(format_parse_context& ctx) const { return ctx.begin(); }
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) const { return ctx.begin(); }
 
   template <typename FormatContext>
   constexpr auto format(const date& d, FormatContext& ctx) const {

--- a/packages.manifest
+++ b/packages.manifest
@@ -1,2 +1,4 @@
 : 1
 location: fmt/
+:
+location: fmt-tests/

--- a/repositories.manifest
+++ b/repositories.manifest
@@ -1,11 +1,6 @@
 : 1
 summary: fmt project repository
 
-#:
-#role: prerequisite
-#location: https://pkg.cppget.org/1/stable
-#trust: ...
-
-#:
-#role: prerequisite
-#location: https://git.build2.org/hello/libhello.git
+:
+role: prerequisite
+location: https://pkg.cppget.org/1/stable


### PR DESCRIPTION
Updates to address issues in modules support provided by the build2 package. See issue #5.